### PR TITLE
Add argument validation via trades.

### DIFF
--- a/src/Request/CityByUuid.php
+++ b/src/Request/CityByUuid.php
@@ -25,6 +25,8 @@ class CityByUuid extends RequestBase implements FormInterface, ModifiableInterfa
      */
     public function execute()
     {
+        $this->validateArguments();
+
         $json = $this->requestHandler->request('/cities/' . $this->uuid, [
           'languages' => $this->languageCodes,
           'includes' => $this->includes,
@@ -33,6 +35,15 @@ class CityByUuid extends RequestBase implements FormInterface, ModifiableInterfa
         $data = json_decode($json);
 
         return CityBase::createFromData($data, $this->form);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateArguments()
+    {
+        $this->validateUuid();
+        $this->validateLanguageCodes();
     }
 
 }

--- a/src/Request/CountryByUuid.php
+++ b/src/Request/CountryByUuid.php
@@ -25,6 +25,8 @@ class CountryByUuid extends RequestBase implements FormInterface, ModifiableInte
      */
     public function execute()
     {
+        $this->validateArguments();
+
         $json = $this->requestHandler->request('/countries/' . $this->uuid, [
           'languages' => $this->languageCodes,
           'includes' => $this->includes,
@@ -34,5 +36,14 @@ class CountryByUuid extends RequestBase implements FormInterface, ModifiableInte
 
         return CountryBase::createFromData($data, $this->form);
     }
+
+   /**
+    * {@inheritdoc}
+    */
+   protected function validateArguments()
+   {
+       $this->validateUuid();
+       $this->validateLanguageCodes();
+   }
 
 }

--- a/src/Request/MultilingualTrait.php
+++ b/src/Request/MultilingualTrait.php
@@ -28,4 +28,12 @@ Trait MultilingualTrait
         return $this;
     }
 
+    protected function validateLanguageCodes()
+    {
+        if (empty($this->languageCodes))
+        {
+          throw new \InvalidArgumentException('Missing language code(s)');
+        }
+    }
+
 }

--- a/src/Request/RequestBase.php
+++ b/src/Request/RequestBase.php
@@ -37,4 +37,12 @@ abstract class RequestBase implements RequestInterface
         return new static($requestHandler);
     }
 
+    /**
+     * Validates arguments before the request takes place.
+     *
+     * @throws \InvalidArgumentException
+     *   Exception thrown when arguments are missing or have an invalid value.
+     */
+    protected function validateArguments() {}
+
 }

--- a/src/Request/UuidTrait.php
+++ b/src/Request/UuidTrait.php
@@ -27,4 +27,12 @@ Trait UuidTrait
         return $this;
     }
 
+    protected function validateUuid()
+    {
+        if (empty($this->uuid))
+        {
+          throw new \InvalidArgumentException('Missing uuid');
+        }
+    }
+
 }


### PR DESCRIPTION
Request have mandatory arguments, but these are not checked before requesting. Although the API handles this correctly, it could save development effort if some basic validation was present in the library.

How about this way of using the traits for validation of their respective data.
This is no final code, but to aid discussion.