### PR TITLE
Argument validation

### DIFF
--- a/src/Request/CityByUuid.php
+++ b/src/Request/CityByUuid.php
@@ -25,6 +25,9 @@ class CityByUuid extends RequestBase implements FormInterface, ModifiableInterfa
      */
     public function execute()
     {
+        $this->validateRequiredUuid();
+        $this->validateRequiredLanguageCodes();
+
         $json = $this->requestHandler->request('/cities/' . $this->uuid, [
           'languages' => $this->languageCodes,
           'includes' => $this->includes,

--- a/src/Request/CountryByUuid.php
+++ b/src/Request/CountryByUuid.php
@@ -25,6 +25,9 @@ class CountryByUuid extends RequestBase implements FormInterface, ModifiableInte
      */
     public function execute()
     {
+        $this->validateRequiredUuid();
+        $this->validateRequiredLanguageCodes();
+
         $json = $this->requestHandler->request('/countries/' . $this->uuid, [
           'languages' => $this->languageCodes,
           'includes' => $this->includes,

--- a/src/Request/MultilingualTrait.php
+++ b/src/Request/MultilingualTrait.php
@@ -23,6 +23,10 @@ Trait MultilingualTrait
 
     public function setLanguageCodes(array $languageCodes)
     {
+        if (empty($languageCodes)) {
+            throw new \InvalidArgumentException('Language code(s) are required.');
+        }
+
         $this->languageCodes = $languageCodes;
 
         return $this;
@@ -31,7 +35,7 @@ Trait MultilingualTrait
     public function validateRequiredLanguageCodes()
     {
         if (empty($this->languageCodes)) {
-            throw new \RuntimeException('Language codes are required.');
+            throw new \RuntimeException('Language code(s) are required.');
         }
     }
 

--- a/src/Request/MultilingualTrait.php
+++ b/src/Request/MultilingualTrait.php
@@ -24,7 +24,7 @@ Trait MultilingualTrait
     public function setLanguageCodes(array $languageCodes)
     {
         if (empty($languageCodes)) {
-            throw new \InvalidArgumentException('Language code(s) are required.');
+            throw new \InvalidArgumentException('No language code(s) provided. Expected array of language code strings.');
         }
 
         $this->languageCodes = $languageCodes;
@@ -35,7 +35,7 @@ Trait MultilingualTrait
     public function validateRequiredLanguageCodes()
     {
         if (empty($this->languageCodes)) {
-            throw new \RuntimeException('Language code(s) are required.');
+            throw new \RuntimeException('No language code(s) provided. Expected array of language code strings.');
         }
     }
 

--- a/src/Request/MultilingualTrait.php
+++ b/src/Request/MultilingualTrait.php
@@ -28,4 +28,11 @@ Trait MultilingualTrait
         return $this;
     }
 
+    public function validateRequiredLanguageCodes()
+    {
+        if (empty($this->languageCodes)) {
+            throw new \RuntimeException('Language codes are required.');
+        }
+    }
+
 }

--- a/src/Request/UuidTrait.php
+++ b/src/Request/UuidTrait.php
@@ -23,7 +23,7 @@ Trait UuidTrait
     public function setUuid($uuid)
     {
         if (empty($uuid)) {
-            throw new \InvalidArgumentException('UUID is required.');
+            throw new \InvalidArgumentException('No UUID provided. Expected uuid string.');
         }
 
         $this->uuid = $uuid;
@@ -34,7 +34,7 @@ Trait UuidTrait
     protected function validateRequiredUuid()
     {
         if (empty($this->uuid)) {
-            throw new \RuntimeException('UUID is required.');
+            throw new \RuntimeException('No UUID provided. Expected uuid string.');
         }
     }
 

--- a/src/Request/UuidTrait.php
+++ b/src/Request/UuidTrait.php
@@ -39,6 +39,3 @@ Trait UuidTrait
     }
 
 }
-
-// 4 test methods
-// validatie-test @depends op setUuid

--- a/src/Request/UuidTrait.php
+++ b/src/Request/UuidTrait.php
@@ -22,9 +22,23 @@ Trait UuidTrait
 
     public function setUuid($uuid)
     {
+        if (empty($uuid)) {
+            throw new \InvalidArgumentException('UUID is required.');
+        }
+
         $this->uuid = $uuid;
 
         return $this;
     }
 
+    protected function validateRequiredUuid()
+    {
+        if (empty($this->uuid)) {
+            throw new \RuntimeException('UUID is required.');
+        }
+    }
+
 }
+
+// 4 test methods
+// validatie-test @depends op setUuid

--- a/tests/Request/CityByUuidTest.php
+++ b/tests/Request/CityByUuidTest.php
@@ -106,6 +106,50 @@ class CityByUuidTest extends RequestBaseTestBase
     }
 
     /**
+     * @covers ::execute
+     *
+     * @expectedException \InvalidArgumentException
+     *
+     * @depends      testExecute
+     */
+    public function testExecuteInvalidUuidRequest()
+    {
+        $this->sut = CityByUuid::create($this->productionRequestHandler);
+
+        $uuid = '';
+        $languageCodes = ['en'];
+
+        $this->sut
+          ->setUuid($uuid)
+          ->setLanguageCodes($languageCodes)
+          ->execute();
+
+        // No assertion. Exception is thrown.
+    }
+
+    /**
+     * @covers ::execute
+     *
+     * @expectedException \InvalidArgumentException
+     *
+     * @depends      testExecute
+     */
+    public function testExecuteInvalidLangcodeRequest()
+    {
+        $this->sut = CityByUuid::create($this->productionRequestHandler);
+
+        $uuid = '3f879f37-21b0-479d-bd74-aa26f72fa328';
+        $languageCodes = [];
+
+        $this->sut
+          ->setUuid($uuid)
+          ->setLanguageCodes($languageCodes)
+          ->execute();
+
+        // No assertion. Exception is thrown.
+    }
+
+    /**
      * Provides data to self::testExecute
      */
     public function providerTestExecute()

--- a/tests/Request/CityByUuidTest.php
+++ b/tests/Request/CityByUuidTest.php
@@ -122,8 +122,6 @@ class CityByUuidTest extends RequestBaseTestBase
           ->setUuid($uuid)
           ->setLanguageCodes($language_codes)
           ->execute();
-
-        $this->fail('Invalid arguments must throw an exception.');
     }
 
     /**

--- a/tests/Request/CityByUuidTest.php
+++ b/tests/Request/CityByUuidTest.php
@@ -116,7 +116,7 @@ class CityByUuidTest extends RequestBaseTestBase
      */
     public function testExecuteInvalidRequest($uuid, $language_codes)
     {
-        $this->sut = CityByUuid::create($this->productionRequestHandler);
+        $this->sut = CityByUuid::create($this->requestHandler);
 
         $this->sut
           ->setUuid($uuid)

--- a/tests/Request/CityByUuidTest.php
+++ b/tests/Request/CityByUuidTest.php
@@ -108,45 +108,22 @@ class CityByUuidTest extends RequestBaseTestBase
     /**
      * @covers ::execute
      *
-     * @expectedException \InvalidArgumentException
-     *
-     * @depends      testExecute
-     */
-    public function testExecuteInvalidUuidRequest()
-    {
-        $this->sut = CityByUuid::create($this->productionRequestHandler);
-
-        $uuid = '';
-        $languageCodes = ['en'];
-
-        $this->sut
-          ->setUuid($uuid)
-          ->setLanguageCodes($languageCodes)
-          ->execute();
-
-        // No assertion. Exception is thrown.
-    }
-
-    /**
-     * @covers ::execute
+     * @dataProvider providerTestExecuteInvalidRequest
      *
      * @expectedException \InvalidArgumentException
      *
      * @depends      testExecute
      */
-    public function testExecuteInvalidLangcodeRequest()
+    public function testExecuteInvalidRequest($uuid, $language_codes)
     {
         $this->sut = CityByUuid::create($this->productionRequestHandler);
 
-        $uuid = '3f879f37-21b0-479d-bd74-aa26f72fa328';
-        $languageCodes = [];
-
         $this->sut
           ->setUuid($uuid)
-          ->setLanguageCodes($languageCodes)
+          ->setLanguageCodes($language_codes)
           ->execute();
 
-        // No assertion. Exception is thrown.
+        $this->fail('Invalid arguments must throw an exception.');
     }
 
     /**
@@ -162,6 +139,23 @@ class CityByUuidTest extends RequestBaseTestBase
           [
             MultipleFormInterface::FORM_COMPACT,
             '\Triquanta\IziTravel\DataType\CompactCityInterface'
+          ],
+        ];
+    }
+
+    /**
+     * Provides data to self::testExecuteInvalidRequest
+     */
+    public function providerTestExecuteInvalidRequest()
+    {
+        return [
+          [
+            '3f879f37-21b0-479d-bd74-aa26f72fa328',
+            []
+          ],
+          [
+            '',
+            ['en', 'nl']
           ],
         ];
     }

--- a/tests/Request/CountryByUuidTest.php
+++ b/tests/Request/CountryByUuidTest.php
@@ -116,7 +116,7 @@ class CountryByUuidTest extends RequestBaseTestBase
      */
     public function testExecuteInvalidRequest($uuid, $language_codes)
     {
-        $this->sut = CountryByUuid::create($this->productionRequestHandler);
+        $this->sut = CountryByUuid::create($this->requestHandler);
 
         $this->sut
           ->setUuid($uuid)

--- a/tests/Request/CountryByUuidTest.php
+++ b/tests/Request/CountryByUuidTest.php
@@ -106,6 +106,50 @@ class CountryByUuidTest extends RequestBaseTestBase
     }
 
     /**
+     * @covers ::execute
+     *
+     * @expectedException \InvalidArgumentException
+     *
+     * @depends      testExecute
+     */
+    public function testExecuteInvalidUuidRequest()
+    {
+        $this->sut = CountryByUuid::create($this->productionRequestHandler);
+
+        $uuid = '';
+        $languageCodes = ['en'];
+
+        $this->sut
+          ->setUuid($uuid)
+          ->setLanguageCodes($languageCodes)
+          ->execute();
+
+        // No assertion. Exception is thrown.
+    }
+
+    /**
+     * @covers ::execute
+     *
+     * @expectedException \InvalidArgumentException
+     *
+     * @depends      testExecute
+     */
+    public function testExecuteInvalidLangcodeRequest()
+    {
+        $this->sut = CountryByUuid::create($this->productionRequestHandler);
+
+        $uuid = '69929d8f-ba82-49b2-88fe-e5a0c687caca';
+        $languageCodes = [];
+
+        $this->sut
+          ->setUuid($uuid)
+          ->setLanguageCodes($languageCodes)
+          ->execute();
+
+        // No assertion. Exception is thrown.
+    }
+
+    /**
      * Provides data to self::testExecute
      */
     public function providerTestExecute()

--- a/tests/Request/CountryByUuidTest.php
+++ b/tests/Request/CountryByUuidTest.php
@@ -108,45 +108,22 @@ class CountryByUuidTest extends RequestBaseTestBase
     /**
      * @covers ::execute
      *
-     * @expectedException \InvalidArgumentException
-     *
-     * @depends      testExecute
-     */
-    public function testExecuteInvalidUuidRequest()
-    {
-        $this->sut = CountryByUuid::create($this->productionRequestHandler);
-
-        $uuid = '';
-        $languageCodes = ['en'];
-
-        $this->sut
-          ->setUuid($uuid)
-          ->setLanguageCodes($languageCodes)
-          ->execute();
-
-        // No assertion. Exception is thrown.
-    }
-
-    /**
-     * @covers ::execute
+     * @dataProvider providerTestExecuteInvalidRequest
      *
      * @expectedException \InvalidArgumentException
      *
      * @depends      testExecute
      */
-    public function testExecuteInvalidLangcodeRequest()
+    public function testExecuteInvalidRequest($uuid, $language_codes)
     {
         $this->sut = CountryByUuid::create($this->productionRequestHandler);
 
-        $uuid = '69929d8f-ba82-49b2-88fe-e5a0c687caca';
-        $languageCodes = [];
-
         $this->sut
           ->setUuid($uuid)
-          ->setLanguageCodes($languageCodes)
+          ->setLanguageCodes($language_codes)
           ->execute();
 
-        // No assertion. Exception is thrown.
+        $this->fail('Invalid arguments must throw an exception.');
     }
 
     /**
@@ -162,6 +139,23 @@ class CountryByUuidTest extends RequestBaseTestBase
           [
             MultipleFormInterface::FORM_COMPACT,
             '\Triquanta\IziTravel\DataType\CompactCountryInterface'
+          ],
+        ];
+    }
+
+    /**
+     * Provides data to self::testExecuteInvalidRequest
+     */
+    public function providerTestExecuteInvalidRequest()
+    {
+        return [
+          [
+            '3f879f37-21b0-479d-bd74-aa26f72fa328',
+            []
+          ],
+          [
+            '',
+            ['en', 'nl']
           ],
         ];
     }

--- a/tests/Request/CountryByUuidTest.php
+++ b/tests/Request/CountryByUuidTest.php
@@ -122,8 +122,6 @@ class CountryByUuidTest extends RequestBaseTestBase
           ->setUuid($uuid)
           ->setLanguageCodes($language_codes)
           ->execute();
-
-        $this->fail('Invalid arguments must throw an exception.');
     }
 
     /**

--- a/tests/Request/MultilingualTraitTest.php
+++ b/tests/Request/MultilingualTraitTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @file
+ * Contains \Triquanta\IziTravel\Tests\Request\MultilingualTraitTest.
+ */
+
+namespace Triquanta\IziTravel\Tests\Request;
+
+use Triquanta\IziTravel\Request\MultilingualTrait;
+
+/**
+ * @coversDefaultClass \Triquanta\IziTravel\Request\MultilingualTrait
+ */
+class MultilingualTraitTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * The language codes.
+     *
+     * @var string[]
+     *   An array of ISO 639-1 alpha-2 language codes.
+     */
+    protected $languageCodes = [];
+
+    /**
+     * An invalid language codes.
+     *
+     * @var string
+     */
+    protected $invalidLanguageCodes;
+
+    /**
+     * The class under test.
+     *
+     * @var \Triquanta\IziTravel\Request\MultilingualTrait
+     */
+    protected $sut;
+
+    public function setUp() {
+
+        $this->languageCodes = ['en', 'nl'];
+        $this->invalidLanguageCodes = [];
+
+        $this->sut = new MultilingualTraitTestTraitImplementation();
+    }
+
+    /**
+     * @covers ::setLanguageCodes
+     */
+    public function testSetLanguageCodes() {
+
+        $this->sut->setLanguageCodes($this->languageCodes);
+
+        $reflection = new \ReflectionProperty($this->sut, 'languageCodes');
+        $reflection->setAccessible(true);
+        $sut_language_codes = $reflection->getValue($this->sut);
+
+        $this->assertSame($this->languageCodes, $sut_language_codes);
+    }
+
+    /**
+     * @covers ::setLanguageCodes
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetInvalidLanguageCodes() {
+
+        $this->sut->setLanguageCodes($this->invalidLanguageCodes);
+
+    }
+
+    /**
+     * @covers ::validateRequiredLanguageCodes
+     * @depends testSetLanguageCodes
+     */
+    public function testValidateLanguageCodes() {
+
+        $this->sut->setLanguageCodes($this->languageCodes);
+
+        $reflection_method = new \ReflectionMethod($this->sut, 'validateRequiredLanguageCodes');
+        $reflection_method->setAccessible(true);
+        $reflection_method->invoke($this->sut);
+
+        // No assertion. Only testing if no exception occurs.
+    }
+
+    /**
+     * @covers ::validateRequiredLanguageCodes
+     * @depends testSetLanguageCodes
+     * @expectedException \RuntimeException
+     */
+    public function testValidateInvalidLanguageCodes() {
+
+        $reflection = new \ReflectionClass($this->sut);
+        $reflection_property = $reflection->getProperty('languageCodes');
+        $reflection_property->setAccessible(true);
+        $reflection_property->setValue($this->sut, $this->invalidLanguageCodes);
+
+        $reflection_method = $reflection->getMethod('validateRequiredLanguageCodes');
+        $reflection_method->setAccessible(true);
+        $reflection_method->invoke($this->sut);
+
+    }
+
+}
+
+class MultilingualTraitTestTraitImplementation
+{
+
+    use MultilingualTrait;
+
+}

--- a/tests/Request/MultilingualTraitTest.php
+++ b/tests/Request/MultilingualTraitTest.php
@@ -66,8 +66,6 @@ class MultilingualTraitTest extends \PHPUnit_Framework_TestCase {
     public function testSetInvalidLanguageCodes() {
 
         $this->sut->setLanguageCodes($this->invalidLanguageCodes);
-
-        $this->fail('Invalid language codes must throw an exception.');
     }
 
     /**
@@ -87,8 +85,6 @@ class MultilingualTraitTest extends \PHPUnit_Framework_TestCase {
         $reflection_method = $reflection->getMethod('validateRequiredLanguageCodes');
         $reflection_method->setAccessible(true);
         $reflection_method->invoke($this->sut);
-
-        $this->fail('Invalid language codes must throw an exception.');
     }
 
 }

--- a/tests/Request/MultilingualTraitTest.php
+++ b/tests/Request/MultilingualTraitTest.php
@@ -60,32 +60,21 @@ class MultilingualTraitTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @covers ::setLanguageCodes
+     *
      * @expectedException \InvalidArgumentException
      */
     public function testSetInvalidLanguageCodes() {
 
         $this->sut->setLanguageCodes($this->invalidLanguageCodes);
 
+        $this->fail('Invalid language codes must throw an exception.');
     }
 
     /**
      * @covers ::validateRequiredLanguageCodes
+     *
      * @depends testSetLanguageCodes
-     */
-    public function testValidateLanguageCodes() {
-
-        $this->sut->setLanguageCodes($this->languageCodes);
-
-        $reflection_method = new \ReflectionMethod($this->sut, 'validateRequiredLanguageCodes');
-        $reflection_method->setAccessible(true);
-        $reflection_method->invoke($this->sut);
-
-        // No assertion. Only testing if no exception occurs.
-    }
-
-    /**
-     * @covers ::validateRequiredLanguageCodes
-     * @depends testSetLanguageCodes
+     *
      * @expectedException \RuntimeException
      */
     public function testValidateInvalidLanguageCodes() {
@@ -99,6 +88,7 @@ class MultilingualTraitTest extends \PHPUnit_Framework_TestCase {
         $reflection_method->setAccessible(true);
         $reflection_method->invoke($this->sut);
 
+        $this->fail('Invalid language codes must throw an exception.');
     }
 
 }

--- a/tests/Request/MultilingualTraitTest.php
+++ b/tests/Request/MultilingualTraitTest.php
@@ -25,7 +25,7 @@ class MultilingualTraitTest extends \PHPUnit_Framework_TestCase {
     /**
      * An invalid language codes.
      *
-     * @var string
+     * @var string[]|null
      */
     protected $invalidLanguageCodes;
 

--- a/tests/Request/UuidTraitTest.php
+++ b/tests/Request/UuidTraitTest.php
@@ -10,16 +10,23 @@ namespace Triquanta\IziTravel\Tests\Request;
 use Triquanta\IziTravel\Request\UuidTrait;
 
 /**
- * @coversDefaultClass \Triquanta\IziTravel\DataType\UuidTrait
+ * @coversDefaultClass \Triquanta\IziTravel\Request\UuidTrait
  */
 class UuidTraitTest extends \PHPUnit_Framework_TestCase {
 
     /**
-    * The UUID.
-    *
-    * @var string
-    */
+     * The UUID.
+     *
+     * @var string
+     */
     protected $uuid;
+
+    /**
+     * An invalid UUID.
+     *
+     * @var string
+     */
+    protected $invalidUuid;
 
     /**
      * The class under test.
@@ -31,6 +38,7 @@ class UuidTraitTest extends \PHPUnit_Framework_TestCase {
     public function setUp() {
 
         $this->uuid = 'foo-bar-baz-' . mt_rand();
+        $this->invalidUuid = '';
 
         $this->sut = new UuidTraitTestTraitImplementation();
     }
@@ -40,28 +48,61 @@ class UuidTraitTest extends \PHPUnit_Framework_TestCase {
      */
     public function testSetUuid() {
 
-        $this->sut->uuid = $this->uuid;
-        $this->assertSame($this->uuid, $this->sut->getUuid());
+        $this->sut->setUuid($this->uuid);
+
+        $reflection = new \ReflectionProperty($this->sut, 'uuid');
+        $reflection->setAccessible(true);
+        $sut_uuid = $reflection->getValue($this->sut);
+
+        $this->assertSame($this->uuid, $sut_uuid);
     }
 
     /**
      * @covers ::setUuid
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testSetInvalidUuid() {
 
-        $this->sut->uuid = $this->uuid;
-        $this->assertSame($this->uuid, $this->sut->getUuid());
+        $this->sut->setUuid($this->invalidUuid);
+
     }
 
     /**
      * @covers ::validateRequiredUuid
-     * @expectedException \RuntimeException
+     *
+     * @depends testSetUuid
      */
     public function testValidateUuid() {
 
-        $this->sut->uuid = NULL;
-        $this->sut->getUuid();
-        $this->sut->validateRequiredUuid();
+        $this->sut->setUuid($this->uuid);
+
+        $reflection_method = new \ReflectionMethod($this->sut, 'validateRequiredUuid');
+        $reflection_method->setAccessible(true);
+        $reflection_method->invoke($this->sut);
+
+        // No assertion. Only testing if no exception occurs.
+
+    }
+
+    /**
+     * @covers ::validateRequiredUuid
+     *
+     * @depends testSetUuid
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testValidateInvalidUuid() {
+
+        $reflection = new \ReflectionClass($this->sut);
+        $reflection_property = $reflection->getProperty('uuid');
+        $reflection_property->setAccessible(true);
+        $reflection_property->setValue($this->sut, $this->invalidUuid);
+
+        $reflection_method = $reflection->getMethod('validateRequiredUuid');
+        $reflection_method->setAccessible(true);
+        $reflection_method->invoke($this->sut);
+
     }
 
 }
@@ -71,10 +112,4 @@ class UuidTraitTestTraitImplementation
 
     use UuidTrait;
 
-    /**
-     * Constructs a new instance.
-     */
-    public function __construct()
-    {
-    }
 }

--- a/tests/Request/UuidTraitTest.php
+++ b/tests/Request/UuidTraitTest.php
@@ -66,23 +66,7 @@ class UuidTraitTest extends \PHPUnit_Framework_TestCase {
 
         $this->sut->setUuid($this->invalidUuid);
 
-    }
-
-    /**
-     * @covers ::validateRequiredUuid
-     *
-     * @depends testSetUuid
-     */
-    public function testValidateUuid() {
-
-        $this->sut->setUuid($this->uuid);
-
-        $reflection_method = new \ReflectionMethod($this->sut, 'validateRequiredUuid');
-        $reflection_method->setAccessible(true);
-        $reflection_method->invoke($this->sut);
-
-        // No assertion. Only testing if no exception occurs.
-
+        $this->fail('Invalid UUID must throw an exception.');
     }
 
     /**
@@ -103,6 +87,7 @@ class UuidTraitTest extends \PHPUnit_Framework_TestCase {
         $reflection_method->setAccessible(true);
         $reflection_method->invoke($this->sut);
 
+        $this->fail('Invalid UUID must throw an exception.');
     }
 
 }

--- a/tests/Request/UuidTraitTest.php
+++ b/tests/Request/UuidTraitTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @file
+ * Contains \Triquanta\IziTravel\Tests\Request\UuidTraitTest.
+ */
+
+namespace Triquanta\IziTravel\Tests\Request;
+
+use Triquanta\IziTravel\Request\UuidTrait;
+
+/**
+ * @coversDefaultClass \Triquanta\IziTravel\DataType\UuidTrait
+ */
+class UuidTraitTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+    * The UUID.
+    *
+    * @var string
+    */
+    protected $uuid;
+
+    /**
+     * The class under test.
+     *
+     * @var \Triquanta\IziTravel\Request\UuidTrait
+     */
+    protected $sut;
+
+    public function setUp() {
+
+        $this->uuid = 'foo-bar-baz-' . mt_rand();
+
+        $this->sut = new UuidTraitTestTraitImplementation();
+    }
+
+    /**
+     * @covers ::setUuid
+     */
+    public function testSetUuid() {
+
+        $this->sut->uuid = $this->uuid;
+        $this->assertSame($this->uuid, $this->sut->getUuid());
+    }
+
+    /**
+     * @covers ::setUuid
+     */
+    public function testSetInvalidUuid() {
+
+        $this->sut->uuid = $this->uuid;
+        $this->assertSame($this->uuid, $this->sut->getUuid());
+    }
+
+    /**
+     * @covers ::validateRequiredUuid
+     * @expectedException \RuntimeException
+     */
+    public function testValidateUuid() {
+
+        $this->sut->uuid = NULL;
+        $this->sut->getUuid();
+        $this->sut->validateRequiredUuid();
+    }
+
+}
+
+class UuidTraitTestTraitImplementation
+{
+
+    use UuidTrait;
+
+    /**
+     * Constructs a new instance.
+     */
+    public function __construct()
+    {
+    }
+}

--- a/tests/Request/UuidTraitTest.php
+++ b/tests/Request/UuidTraitTest.php
@@ -65,8 +65,6 @@ class UuidTraitTest extends \PHPUnit_Framework_TestCase {
     public function testSetInvalidUuid() {
 
         $this->sut->setUuid($this->invalidUuid);
-
-        $this->fail('Invalid UUID must throw an exception.');
     }
 
     /**
@@ -86,8 +84,6 @@ class UuidTraitTest extends \PHPUnit_Framework_TestCase {
         $reflection_method = $reflection->getMethod('validateRequiredUuid');
         $reflection_method->setAccessible(true);
         $reflection_method->invoke($this->sut);
-
-        $this->fail('Invalid UUID must throw an exception.');
     }
 
 }


### PR DESCRIPTION
To prevent invalid API requests, validation of required arguments is added to 'country by uuid' and 'city by uuid' requests.
